### PR TITLE
Update club name and URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Hosting a Bitcoin Core Review Club Meeting
+# Hosting an LND Review Club Meeting
 
 Some tips for hosting a great review club meeting:
 
@@ -31,8 +31,8 @@ Some tips for hosting a great review club meeting:
 - When linking to code, use stable links that won't break later:
 
   - for links to code in the master branch, link to a recent commit hash in
-    the master branch of bitcoin/bitcoin, e.g.
-    [https://github.com/bitcoin/bitcoin/blob/23d3ae7a/src/addrman.cpp#L44](https://github.com/bitcoin/bitcoin/blob/23d3ae7a/src/addrman.cpp#L44).
+    the master branch of lightningnetwork/lnd, e.g.
+    [https://github.com/lightningnetwork/lnd/blob/bfa1cf17/lnd/lnwallet/parameters.go#L76](https://github.com/lightningnetwork/lnd/blob/bfa1cf17/lnd/lnwallet/parameters.go#L76).
     You can use a short (8 character) commit id.
 
     **REASON**: linking directly to master
@@ -40,9 +40,9 @@ Some tips for hosting a great review club meeting:
 
   - for links to code in the PR branch, ask one of the
     review club maintainers to add a tag of the current PR branch
-    to [bitcoin-core-review-club/bitcoin](https://github.com/bitcoin-core-review-club/bitcoin),
+    to [lndreviews/lnd](https://github.com/lndreviews/lnd),
     and link to that branch or a commit on that branch, e.g.
-    [https://github.com/bitcoin-core-review-club/bitcoin/commit/a6ca5080#diff-be2905e2f5218ecdbe4e55637dac75f3R1751-R1754](https://github.com/bitcoin-core-review-club/bitcoin/commit/a6ca5080#diff-be2905e2f5218ecdbe4e55637dac75f3R1751-R1754).
+    [https://github.com/lndreviews/lnd/commit/a6ca5080#diff-be2905e2f5218ecdbe4e55637dac75f3R1751-R1754](https://github.com/lndreviews/lnd/commit/a6ca5080#diff-be2905e2f5218ecdbe4e55637dac75f3R1751-R1754).
     You can use a short (8 character) commit id.
 
     **REASON**: if the PR author modifies
@@ -114,7 +114,7 @@ rake posts:new -- --help
   in Bitcoin?") don't get a good response because all the attendees are waiting for
   someone else to answer. Instead try to make the questions focused on the
   PR or change set that is being reviewed (e.g. "how does commit X change the
-  way bitcoind gossips transactions?"). Try to phrase questions positively
+  way lnd gossips channel updates?"). Try to phrase questions positively
   ("please describe how X works") rather than negatively ("Does anyone not know
   how X works?").
 
@@ -155,28 +155,28 @@ _This process is done by the review club maintainers_
   ```
 
 - Add the first 7 characters of the PR commit hash at HEAD to the meeting post.
-  This adds a link to the tagged branch on the review club bitcoin core repo.
+  This adds a link to the tagged branch on the review club LND core repo.
   ```diff
   -commit:
   +commit: eebaca7
   ```
 
 - Push a tag of the branch at the time of the meeting to the [PR Review Club
-  Bitcoin repo](https://github.com/bitcoin-core-review-club/bitcoin). This is so
+  LND repo](https://github.com/lndreviews/lnd). This is so
   if the PR branch changes after the review club meeting, people reading the
   notes and log later can see the branch as it was at the time of the meeting:
 
-  - Run these steps from the root of your local bitcoin repo.
+  - Run these steps from the root of your local LND repo.
 
     ```shell
-    cd bitcoin
+    cd lnd
     ```
 
-  - The first time you do this, you'll need to add the review club bitcoin
+  - The first time you do this, you'll need to add the review club lnd
     repo to your git remotes: 
 
     ```shell
-    git remote add review-club git@github.com:bitcoin-core-review-club/bitcoin.git
+    git remote add review-club git@github.com:lndreviews/lnd.git
     ```
 
   - Push a tag to the review-club remote

--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ COMPONENTS = DESIRED_COMPONENTS.map(&:downcase).freeze
 # Characters or words we want removed after the prefix can go into this array.
 UNDESIRED_PR_TITLE_WORDS = %w(- _).freeze
 
-GITHUB_API_URL = 'https://api.github.com/repos/bitcoin/bitcoin/pulls'
+GITHUB_API_URL = 'https://api.github.com/repos/lightningnetwork/lnd/pulls'
 HTTP_SUCCESS  = '200'
 HTTP_NOTFOUND = '404'
 HTTP_ERRORS = [
@@ -198,7 +198,7 @@ def create_post_file!(filename, response, date, host)
     line.puts "<!-- TODO: Before meeting, add notes and questions"
     line.puts "## Notes\n\n"
     line.puts "## Questions"
-    line.puts "1. Did you review the PR? [Concept ACK, approach ACK, tested ACK, or NACK](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-review)?"
+    line.puts "1. Did you review the PR? [Concept ACK, approach ACK, tested ACK, or NACK](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-approval-process)?"
     line.puts "-->\n\n\n"
     line.puts "<!-- TODO: After meeting, uncomment and add meeting log between the irc tags"
     line.puts "## Meeting Log\n\n"

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -32,8 +32,8 @@ layout: default
 
     {% if page.pr %}
       <p style="font-weight:bold">
-        <a href="https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}">
-          https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}
+        <a href="https://github.com/lightningnetwork/lnd/pull/{{ page.pr }}">
+          https://github.com/lightningnetwork/lnd/pull/{{ page.pr }}
         </a>
       </p>
     {% elsif page.link %}
@@ -58,7 +58,7 @@ layout: default
 
     {% if page.status == "past" %}
       {% if page.commit %}
-      <p><em>The PR branch HEAD was <a href="https://github.com/bitcoin-core-review-club/bitcoin/tree/pr{{ page.id | remove_first: "/#" }}/">{{ page.commit }}</a> at the time of this review club meeting.</em><p>
+      <p><em>The PR branch HEAD was <a href="https://github.com/lndreviews/lnd/tree/pr{{ page.id | remove_first: "/#" }}/">{{ page.commit }}</a> at the time of this review club meeting.</em><p>
       {%- endif -%}
     {%- endif -%}
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Code of Conduct
+permalink: /code-of-conduct/
 ---
 
 # Code of Conduct

--- a/index.md
+++ b/index.md
@@ -65,7 +65,7 @@ volunteer hosts to lead the discussion:
 
 - To suggest a PR, please DM @lucasdcf on [Slack](https://lightning.engineering/slack.html), IRC, or Twitter.
 - If you'd like to host a meeting, look at the [information for meeting
-  hosts](https://github.com/bitcoin-core-review-club/bitcoin-core-review-club.github.io/blob/master/CONTRIBUTING.md)
+  hosts](https://github.com/lndreviews/website/blob/master/CONTRIBUTING.md)
   and contact lucasdcf on on [Slack](https://lightning.engineering/slack.html), IRC, or Twitter.
 
 ## Recent Meetings

--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ process](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribut
 on GitHub.
 
 <span class="question">How do I take part?</span> Just show up on IRC! See
-[Attending your first PR Review Club](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-review) 
+[Attending your first PR Review Club](/your-first-meeting/)
 for more tips on how to participate.
 
 <span class="question">Who runs this?</span> &nbsp;Lightning Labs evangelist

--- a/your-first-meeting.md
+++ b/your-first-meeting.md
@@ -34,11 +34,11 @@ IRC](https://fedoramagazine.org/beginners-guide-irc/).
 You’ll get the most out of Review Club if you’ve reviewed the PR going into the
 meeting, but it’s definitely not mandatory in order to attend. You can always
 show up as an observer. If you're worried (don't be!), read the meeting log of a
-[past PR Review Club](https://bitcoincore.reviews/meetings/). You'll see it's
+[past PR Review Club](https://lnd.reviews/meetings/). You'll see it's
 very casual.
 
-If you’d like to more actively participate, you should clone the [Bitcoin
-repository](https://github.com/bitcoin/bitcoin). You should also check out and
+If you’d like to more actively participate, you should clone the [LND
+repository](https://github.com/lightningnetwork/lnd). You should also check out and
 build the PR branch locally and run all tests. Take time to review the code changes and
 read the comments on that week’s PR.
 
@@ -56,7 +56,7 @@ let you know. The host will end the session with **#endmeeting**
 at the end of the hour. Thanking the host at the end of the meeting is always
 appreciated!
 
-Follow the [PR Review Club on Twitter](https://twitter.com/BitcoinCorePRs) for
+Follow the [PR Review Club on Twitter](https://twitter.com/) (coming soon) for
 announcements on that week’s PR or schedule changes.
 
 **We look forward to having you at the next PR Review Club!**

--- a/your-first-meeting.md
+++ b/your-first-meeting.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Attending your first PR Review Club
+permalink: /your-first-meeting/
 ---
 
 ## Attending your first PR Review Club


### PR DESCRIPTION
Since this repo was forked from `bitcoin-core-review-club`, there are some remnants of that site left over. This PR attempts to update all remaining references to the old Club Name and URLs (`lnd.reviews` and `github.com/lndreviews/...`)

Some tasks remain to make the site completely accurate:
- Verify the [code-of-conduct](https://lnd.reviews/code-of-conduct/) and [your-first-meeting](https://lnd.reviews/your-first-meeting/) pages are published once this is merged
- A second github repo should be created: `lndreviews/lnd`
    - Push a sample PR branch from LND repo as tag in `lndreviews/lnd`
    - Update example PR branch link to the real sample branch
- Update twitter account link (or remove link)

I will be glad to assist with any of these, just let me know how I can help.