### PR TITLE
update slack channel to #review-club

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ description:       "A weekly review club for LND PRs"
 author:            "LND PR Review Club contributors"
 meeting_time:      "TBD"
 meeting_day:       "TBD"
-meeting_location:  '#pr-reviews channel on <a href="https://lightning.engineering/slack.html">LND Developer Community Slack</a>'
+meeting_location:  '#review-club channel on <a href="https://lightning.engineering/slack.html">LND Developer Community Slack</a>'
 future: true
 url: https://lnd.reviews
 twitter_username: 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,9 @@ title: home
 ### A weekly review club for LND PRs
 
 <span class="question">What is this?</span> &nbsp;A weekly club for reviewing
-LND PRs **every two weeks on Thursdays at 17:00 UTC** in the #pr-reviews channel on [LND Developer Community Slack](https://lightning.engineering/slack.html).
+LND PRs **every two weeks on Thursdays at 17:00 UTC** in the
+#review-club channel on
+[LND Developer Community Slack](https://lightning.engineering/slack.html).
 
 <span class="question">What's it for?</span> &nbsp;To help newer contributors
 learn about the LND review process. The review club is *not* primarily

--- a/your-first-meeting.md
+++ b/your-first-meeting.md
@@ -9,7 +9,9 @@ permalink: /your-first-meeting/
 If you’re thinking about attending PR Review Club, welcome! We love new
 participants. Below is information to help you get started as a first-timer.
 
-The club meets **every two weeks on Thursdays at 17:00 UTC** in the #pr-reviews channel on [LND Developer Community Slack](https://lightning.engineering/slack.html). Every week, an LND
+The club meets **every two weeks on Thursdays at 17:00 UTC** in the
+#review-club channel on [LND Developer Community
+Slack](https://lightning.engineering/slack.html). Every week, an LND
 developer will host a 60-minute discussion on an LND pull request. [The
 code of conduct](https://lnd.reviews/code-of-conduct) details the
 behavior we expect from all participants.


### PR DESCRIPTION
Previously we had written `#pr-reviews`. Today the `#review-club` channel was created in Slack, matching the launch announcement on twitter. This PR updates all mentions of the channel to `#review-club`.